### PR TITLE
Implement "Server Console" output channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "onCommand:extension.uploadScriptsFromFolder",
     "onCommand:extension.downloadScriptsToFolder",
     "onCommand:extension.getScriptNames",
-    "onCommand:extension.getScriptParameters"
+    "onCommand:extension.getScriptParameters",
+    "onDebug:janus"
   ],
   "main": "./out/src/extension",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -443,6 +443,7 @@
   "devDependencies": {
     "@types/mocha": "^2.2.41",
     "@types/node": "^7.0.22",
+    "@types/strip-json-comments": "0.0.28",
     "@types/utf8": "^2.1.5",
     "mocha": "^2.4.5",
     "tslint": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -257,6 +257,17 @@
           "type": "array",
           "default": [],
           "description": "Names of all scripts on server."
+        },
+        "vscode-janus-debug.serverConsole": {
+          "type": "object",
+          "title": "Server Console",
+          "properties": {
+            "autoConnect": {
+              "type": "boolean",
+              "default": true,
+              "description": "Try to auto connect Server Console every time the launch.json is changed"
+            }
+          }
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,19 +133,24 @@ export function activate(context: vscode.ExtensionContext): void {
     outputChannel.appendLine('Extension activated');
     outputChannel.show();
     serverConsole = new ServerConsole(outputChannel);
-    reconnectServerConsole(serverConsole);
 
-    launchJsonWatcher = vscode.workspace.createFileSystemWatcher('**/launch.json',
-        false, false, false);
-    launchJsonWatcher.onDidCreate(() => {
-        outputChannel.appendLine('launch.json created; trying to connect...');
+    const extensionSettings = vscode.workspace.getConfiguration('vscode-janus-debug');
+    const autoConnectEnabled = extensionSettings.get('serverConsole.autoConnect', true);
+    if (autoConnectEnabled) {
         reconnectServerConsole(serverConsole);
-    });
-    launchJsonWatcher.onDidChange(() => {
-        outputChannel.appendLine('launch.json changed; trying to (re)connect...');
-        reconnectServerConsole(serverConsole);
-    });
-    launchJsonWatcher.onDidDelete(() => disconnectServerConsole(serverConsole));
+
+        launchJsonWatcher = vscode.workspace.createFileSystemWatcher('**/launch.json',
+            false, false, false);
+        launchJsonWatcher.onDidCreate(() => {
+            outputChannel.appendLine('launch.json created; trying to connect...');
+            reconnectServerConsole(serverConsole);
+        });
+        launchJsonWatcher.onDidChange(() => {
+            outputChannel.appendLine('launch.json changed; trying to (re)connect...');
+            reconnectServerConsole(serverConsole);
+        });
+        launchJsonWatcher.onDidDelete(() => disconnectServerConsole(serverConsole));
+    }
 
     context.subscriptions.push(
         vscode.commands.registerCommand('extension.vscode-janus-debug.askForPassword', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as commands from './commands';
 import { provideInitialConfigurations } from './config';
+import { extend } from './helpers';
 import * as login from './login';
 import { ServerConsole } from './serverConsole';
 import stripJsonComments = require('strip-json-comments');
@@ -14,21 +15,6 @@ const DOCUMENTS_SETTINGS = 'documents-scripting-settings.json';
 
 let launchJsonWatcher: vscode.FileSystemWatcher;
 let serverConsole: ServerConsole;
-
-/**
- * Extends an object with another object's properties.
- *
- * Merges the properties of two objects together into the first object.
- *
- * @param target The object that will receive source's properties.
- * @param source An object carrying additional properties.
- */
-function extend<T, U>(target: T, source: U): T & U {
-    const s: any = source;
-    const t: any = target;
-    Object.keys(s).forEach(key => t[key] = s[key]);
-    return t;
-}
 
 /**
  * Reads and returns the launch.json file's configurations.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,7 +95,7 @@ async function reconnectServerConsole(console: ServerConsole): Promise<void> {
     let port: number | undefined;
 
     try {
-        console.disconnect();
+        await console.disconnect();
 
         const launchJson = await getLaunchConfigFromDisk();  // vscode.workspace.getConfiguration('launch');
         const configs: any[] = launchJson.get('configurations', []);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -23,6 +23,21 @@ const NO_CONFLICT = 'No conflict';
 const CACHE_FILE = '.documents-scripting-cache';
 
 /**
+ * Extends an object with another object's properties.
+ *
+ * Merges the properties of two objects together into the first object.
+ *
+ * @param target The object that will receive source's properties.
+ * @param source An object carrying additional properties.
+ */
+export function extend<T, U>(target: T, source: U): T & U {
+    const s: any = source;
+    const t: any = target;
+    Object.keys(s).forEach(key => t[key] = s[key]);
+    return t;
+}
+
+/**
  * Subfunction of ensureUploadScripts.
  *
  * @param script

--- a/src/serverConsole.ts
+++ b/src/serverConsole.ts
@@ -111,6 +111,8 @@ export class ServerConsole {
                                     for (const line of messages.lines) {
                                         this.printLogLine(line);
                                     }
+                                    this.lastSeen = messages.lastSeen;
+
                                 }).then(() => {
                                     taskIsRunning = false;
                                 });

--- a/src/serverConsole.ts
+++ b/src/serverConsole.ts
@@ -154,13 +154,13 @@ export class ServerConsole {
     }
 
     public async disconnect(): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
+        return new Promise<void>(async (resolve, reject) => {
             if (!this.conn) {
                 resolve();
             } else {
-                const conn = this.conn;
+                await this.conn.disconnect();
                 this.conn = undefined;
-                return conn.disconnect();
+                resolve();
             }
         });
     }

--- a/src/serverConsole.ts
+++ b/src/serverConsole.ts
@@ -1,0 +1,131 @@
+'use strict';
+
+import * as assert from 'assert';
+import { connect } from 'net';
+import { crypt_md5, SDSConnection } from 'node-sds';
+import { Logger } from './log';
+
+export interface Output {
+    append(value: string): void;
+    appendLine(value: string): void;
+    clear(): void;
+    dispose(): void;
+    hide(): void;
+    show(preserveFocus?: boolean): void;
+    show(column?: any, preserveFocus?: boolean): void;
+}
+
+export interface ServerConsoleConfig {
+    /**
+     * Hostname or IP address of target server.
+     */
+    hostname: string;
+
+    /**
+     * TCP port of application. Usually 11000.
+     */
+    port: number;
+
+    /**
+     * Number of milliseconds we wait until we poll the server again for new
+     * messages. Optional. Default is 3000.
+     */
+    refreshRate?: number;
+}
+
+const log = Logger.create(`ServerConsole`);
+
+export class ServerConsole {
+
+    private conn: SDSConnection;
+    private lastSeen: number;
+
+    constructor(private config: ServerConsoleConfig, private out: Output) {
+        assert.ok(config.hostname.length !== 0);
+        assert.ok(config.port > 0);
+
+        this.lastSeen = 0;
+    }
+
+    public async start() {
+        return new Promise<void>((resolve, reject) => {
+            if (this.conn) {
+                resolve();
+                return;
+            }
+
+            this.out.show();
+            log.debug(`connecting to ${this.config.port}:${this.config.hostname}`);
+            const sock = connect(this.config.port, this.config.hostname);
+            this.conn = new SDSConnection(sock);
+
+            sock.on('connect', () => {
+                this.conn.connect('server-console').then(() => {
+
+                    /*
+
+                    Providing credentials is not necessary but this is a bug:
+                    https://redmine.otris.de/issues/20065
+
+                        return conn.changeUser('', '');
+                    }).then(userId => {
+                        return conn.changePrincipal('');
+                    }).then(() => {
+
+                    */
+
+                    return this.conn.getLogMessages(-1);
+                }).then((messages) => {
+
+                    for (const line of messages.lines) {
+                        this.print(line);
+                    }
+
+                    this.lastSeen = messages.lastSeen;
+
+                }).then(() => {
+
+                    const pollingInterval = this.config.refreshRate || 3000;
+                    let taskIsRunning = false;
+                    setInterval(async () => {
+                        if (!taskIsRunning) {
+                            taskIsRunning = true;
+                            await this.conn.getLogMessages(this.lastSeen).then(messages => {
+                                for (const line of messages.lines) {
+                                    this.print(line);
+                                }
+                            }).then(() => {
+                                taskIsRunning = false;
+                            });
+                        }
+                    }, pollingInterval);
+
+                }).catch(((reason: Error | string) => {
+                    log.error(`error in 'connect' event handler: ${reason.toString()}`);
+                    reject(reason.toString());
+                }));
+
+                sock.on('error', (err: Error) => {
+                    log.error(err.toString());
+                    reject(err.toString());
+                });
+
+                sock.on('close', (hadError: boolean) => {
+                    let msg = 'remote closed the connection';
+                    if (hadError) {
+                        msg += ' because of an error';
+                        log.error(msg);
+                        reject(msg);
+                    } else {
+                        log.debug(msg);
+                        resolve();
+                    }
+                });
+            });
+        });
+    }
+
+    private print(line: string) {
+        this.out.appendLine(`→ ${line}`);
+    }
+}


### PR DESCRIPTION
This PR adds access to a remote JANUS server's console output to this extension. This PR resolves #26.

## Motivation
Normally, developers access the remote server's logs by ssh'ing into the remote server and do something like `tail -f` on the log file or use the server console application on Windows.

![Windows Server Console](https://user-images.githubusercontent.com/536464/27292286-4e215d28-5513-11e7-8bcd-8eeace92e7c5.png)

This PR adds access to the server log lines directly from within VS Code so that the developer is not forced to use another application or to open a terminal.

## Feature
The default behavior is as follows: As soon as the extension is activated and--after that--whenever the `launch.json` file is changed, the extension tries to connect to the remote server and get access to the server's log lines. The lines are printed to a new output channel named "Server Console" as shown in the screenshot below.

![vscode-server-console](https://user-images.githubusercontent.com/536464/27292779-be619dcc-5514-11e7-926f-c5ef13612f5c.png)

In order to re-connect or change the the connection parameters the user just needs to save the `launch.json` file.

To turn off automatic (re-)connection of the server console, the user can add something like the following to his workspace or system configuration:

```json
{
    "vscode-janus-debug.serverConsole": {
        "autoConnect": false
    }
}
```

## Implementation

This PR adds:

* One new configuration contribution point to the extension: `"vscode-janus-debug.serverConsole"`. See changes in `package.json`.

* A new class `ServerConsole`, that creates a new TCP connection to the server, prints the log lines to an abstract `Output` interface, and polls the server for new log lines.

* Code in `extension.activate` that creates the output channel and shows it as soon as the extension is activated.

* Code in `extension.ts` that creates a FileSystemWatcher object on `launch.json`, registering several event listeners that read the new configuration from the `launch.json` file and trigger a (re-)connect of the server console.