### PR TITLE
Fix "timeout" behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
               },
               "timeout": {
                 "type": "number",
-                "description": "Time in ms until we give up trying to connect.",
+                "description": "Time in ms until we give up trying to connect or waiting for an answer.",
                 "default": 6000
               },
               "stopOnEntry": {
@@ -161,7 +161,7 @@
               },
               "timeout": {
                 "type": "number",
-                "description": "Time in ms until we give up trying to connect.",
+                "description": "Time in ms until we give up trying to connect or waiting for an answer.",
                 "default": 6000
               },
               "log": {

--- a/package.json
+++ b/package.json
@@ -97,11 +97,6 @@
                 "description": "Time in ms until we give up trying to connect.",
                 "default": 6000
               },
-              "sdsTimeout": {
-                "type": "number",
-                "description": "Time in ms until we give up waiting for a response.",
-                "default": 60000
-              },
               "stopOnEntry": {
                 "type": "boolean",
                 "description": "Automatically pause script after launch.",
@@ -168,11 +163,6 @@
                 "type": "number",
                 "description": "Time in ms until we give up trying to connect.",
                 "default": 6000
-              },
-              "sdsTimeout": {
-                "type": "number",
-                "description": "Time in ms until we give up waiting for a response.",
-                "default": 60000
               },
               "log": {
                 "type": "object",

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,7 @@ const initialConfigurations = [
                 default: 'Debug',
             },
         },
+        timeout: 6000
     },
     {
         name: 'Attach to Server',
@@ -73,6 +74,7 @@ const initialConfigurations = [
                 default: 'Debug',
             },
         },
+        timeout: 6000
     },
 ];
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,6 +79,7 @@ async function reconnectServerConsole(console: ServerConsole): Promise<void> {
 
     let hostname: string | undefined;
     let port: number | undefined;
+    let timeout: number | undefined;
 
     try {
         await console.disconnect();
@@ -90,6 +91,7 @@ async function reconnectServerConsole(console: ServerConsole): Promise<void> {
             if (config.hasOwnProperty('type') && config.type === 'janus') {
                 hostname = config.host;
                 port = config.applicationPort;
+                timeout = config.timeout;
                 break;
             }
         }
@@ -98,7 +100,7 @@ async function reconnectServerConsole(console: ServerConsole): Promise<void> {
     }
 
     if (hostname && port) {
-        console.connect({ hostname, port });
+        console.connect({ hostname, port, timeout });
     }
 }
 

--- a/src/serverConsole.ts
+++ b/src/serverConsole.ts
@@ -31,6 +31,12 @@ export interface Config {
      * messages. Optional. Default is 3000.
      */
     refreshRate?: number;
+
+    /**
+     * Time in milliseconds until we give up trying to connect or waiting
+     * for an answer. Optional. Default is 3000.
+     */
+    timeout?: number;
 }
 
 const log = Logger.create(`ServerConsole`);
@@ -76,8 +82,8 @@ export class ServerConsole {
                 sock = createConnection(config.port, config.hostname, () => {
                     this.conn = new SDSConnection(sock);
                     const conn = this.conn;
-
-                    this.conn.connect('server-console').then(() => {
+                    conn.timeout = config.timeout || 6000;
+                    conn.connect('server-console').then(() => {
 
                         /*
 


### PR DESCRIPTION
This PR cleans-up connection timeout handling in vcode-janus-debug. Fixes issue #51.

Changes in this PR:

*  `"sdsTimeout"` property is removed from JSON schema of `launch.json` file. Users are expected to just use `"timeout"` for all network-related timeouts. This should be less confusing for users.
* Make Server Console honor the `"timeout"` property  if set by the user. Previously, the server console just ignored any custom timeouts set by the user :disappointed: 
* `"timeout"` property is now in `launch.json` when the file is newly created.