### PR TITLE
Add keyboard shortcuts (#84)

### DIFF
--- a/package.json
+++ b/package.json
@@ -359,6 +359,24 @@
         "category": "DOCUMENTS"
       }
     ],
+    "keybindings": [
+      {
+        "key": "ctrl+alt+u",
+        "command": "extension.vscode-janus-debug.uploadScript"
+      },  
+      {
+        "key": "ctrl+alt+r",
+        "command": "extension.vscode-janus-debug.runScript"
+      },
+      {
+        "key": "ctrl+alt+x",
+        "command": "extension.vscode-janus-debug.uploadRunScript"
+      },
+      {
+        "key": "ctrl+alt+j",
+        "command": "extension.vscode-janus-debug.uploadJSFromTS"
+      }
+    ],
     "menus": {
       "explorer/context": [
         {


### PR DESCRIPTION
 This commit adds shortcuts for the following commands:
 * uploadScript (ctrl+alt+u)
 * runScript (ctrl+alt+r)
 * uploadRunScript (ctrl+alt+x)
 * uploadJSFromTS (ctrl+alt+j)