### PR TITLE
Establish recursive upload of directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ You'll find a complete list of changes at our project site on [GitHub](https://g
 
 New Features in this release:
  - Users can now use keyboard shortcuts for uploading, running, uploading and running, and uploading from ts to js ([#84](https://github.com/otris/vscode-janus-debug/issues/84)).
-
+ - Uploading directories is now done recursively. Before 0.0.10 uploading directories did not include scripts from subdirectories. ([#72](https://github.com/otris/vscode-janus-debug/issues/72))
 Following bugs have been addressed in this release:
 
 ### 0.0.9 (2017-07-19)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -140,40 +140,52 @@ export function uploadRunScript(loginData: nodeDoc.LoginData, param: any, myOutp
 /**
  * Upload all
  */
-export function uploadAll(loginData: nodeDoc.LoginData, _param: any) {
-    helpers.ensurePath(_param).then((folder) => {
-        return nodeDoc.getScriptsFromFolder(folder[0]).then((folderScripts) => {
+export async function uploadAll(loginData: nodeDoc.LoginData, paramFolderName: string) {
+    try {
+        const folder = await helpers.ensurePath(paramFolderName);
+        const folderScripts = await nodeDoc.getScriptsFromFolder(folder[0]);
 
-            // reads conflict modes and hash values
-            helpers.readHashValues(folderScripts);
-            // read encryption flags
-            helpers.readEncryptionFlag(folderScripts);
+        // reads conflict modes and hash values
+        helpers.readHashValues(folderScripts);
+        // read encryption flags
+        helpers.readEncryptionFlag(folderScripts);
 
-            return nodeDoc.sdsSession(loginData, folderScripts, nodeDoc.uploadAll).then((value1) => {
-                const retScripts: nodeDoc.scriptT[] = value1;
+        const retScripts: nodeDoc.scriptT[] = await nodeDoc.sdsSession(loginData, folderScripts, nodeDoc.uploadAll);
 
-                // ask user about how to handle conflict scripts
-                helpers.ensureForceUpload(retScripts).then(([noConflict, forceUpload]) => {
+        // ask user about how to handle conflict scripts
+        const [noConflict, forceUpload] = await helpers.ensureForceUpload(retScripts);
 
-                    // forceUpload might be empty, function resolves anyway
-                    nodeDoc.sdsSession(loginData, forceUpload, nodeDoc.uploadAll).then((value2) => {
-                        const retScripts2: nodeDoc.scriptT[] = value2;
+        // forceUpload might be empty, function resolves anyway
+        try {
+            const retScripts2: nodeDoc.scriptT[] = await nodeDoc.sdsSession(loginData, forceUpload, nodeDoc.uploadAll);
 
-                        // retscripts2 might be empty
-                        const uploaded = noConflict.concat(retScripts2);
 
-                        helpers.updateHashValues(uploaded);
+            // retscripts2 might be empty
+            const uploaded = noConflict.concat(retScripts2);
 
-                        vscode.window.setStatusBarMessage('uploaded ' + uploaded.length + ' scripts from ' + folder[0]);
-                    }).catch((reason) => {
-                        vscode.window.showErrorMessage('force upload of conflict scripts failed: ' + reason);
-                    });
-                });
-            });
+            helpers.updateHashValues(uploaded);
+
+            vscode.window.setStatusBarMessage('uploaded ' + uploaded.length + ' scripts from ' + folder[0]);
+        } catch (reason) {
+            vscode.window.showErrorMessage('force upload of conflict scripts failed: ' + reason);
+        }
+        // Upload sub folders recursively
+        // get the sub-dirs
+        const subDirs: string[] = fs.readdirSync(paramFolderName);
+        subDirs.map( subDir => { // prepend parent path to sub elements
+            return path.join(paramFolderName,  subDir);
+        }).map(subDir => {
+            if (fs.statSync(subDir).isDirectory()) { // upload the next sub directory
+                uploadAll(loginData, subDir);
+            } else { // return an empty promise, if the sub element is not a directory
+                return new Promise(res => res());
+            }
+        }).map(async promise => { // wait all uploads to finish
+            await promise;
         });
-    }).catch((reason) => {
+    } catch (reason) {
         vscode.window.showErrorMessage('upload all failed: ' + reason);
-    });
+    }
 }
 
 /**

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -174,9 +174,9 @@ export async function uploadAll(loginData: nodeDoc.LoginData, paramFolderName: s
         const subDirs: string[] = fs.readdirSync(paramFolderName);
         subDirs.map( subDir => { // prepend parent path to sub elements
             return path.join(paramFolderName,  subDir);
-        }).map(subDir => {
-            if (fs.statSync(subDir).isDirectory()) { // upload the next sub directory
-                uploadAll(loginData, subDir);
+        }).map(subDirFullPath => {
+            if (fs.statSync(subDirFullPath).isDirectory()) { // upload the next sub directory
+                uploadAll(loginData, subDirFullPath);
             } else { // return an empty promise, if the sub element is not a directory
                 return new Promise(res => res());
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -266,12 +266,16 @@ export function activate(context: vscode.ExtensionContext): void {
 
     // Upload all
     context.subscriptions.push(
-        vscode.commands.registerCommand('extension.vscode-janus-debug.uploadScriptsFromFolder', (param) => {
+        vscode.commands.registerCommand('extension.vscode-janus-debug.uploadScriptsFromFolder', async (param) => {
             let fsPath;
             if (param) {
                 fsPath = param._fsPath;
             }
-            commands.uploadAll(loginData, fsPath);
+            if (await commands.uploadAll(loginData, fsPath) === 'success') {
+                vscode.window.setStatusBarMessage('uploaded all scripts successfully');
+            } else {
+                vscode.window.setStatusBarMessage('failed to upload all scripts');
+            }
         })
     );
 


### PR DESCRIPTION
Now the command "Upload Scripts From Folder" of the context menu is also able to upload scripts in subdirectories.

At the moment it is not able to put scripts from subdirectories into subdirectories.

Solves issue #72 