### PR TITLE
Log version of remote's JSRDBG library to debugger log files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ New Features in this release:
 
 - Add ``noLib: true`` to ``compilerOptions`` part in ``jsconfig.json`` when command **Install Intellisense Files** is executed.
 
+- The version of the remote debugger is no logged in the log file of the requests. The line begins with "Determined version".
+
 Following bugs have been addressed in this release:
 
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -59,6 +59,8 @@ export class DebugConnection extends EventEmitter implements ConnectionLike {
 
         if ( response.type === "info" && response.subtype && response.subtype === "paused") {
             this.emit('contextPaused', response.contextId);
+        }else if ( response.type === "info" && response.subtype && response.subtype === "server_version") {
+            this.emit('serverVersion', response.content );
         }
 
         // No response handler; let the context coordinator decide on how to handle the response

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -59,8 +59,6 @@ export class DebugConnection extends EventEmitter implements ConnectionLike {
 
         if ( response.type === "info" && response.subtype && response.subtype === "paused") {
             this.emit('contextPaused', response.contextId);
-        }else if ( response.type === "info" && response.subtype && response.subtype === "server_version") {
-            this.emit('serverVersion', response.content );
         }
 
         // No response handler; let the context coordinator decide on how to handle the response

--- a/src/debugSession.ts
+++ b/src/debugSession.ts
@@ -69,10 +69,9 @@ export class JanusDebugSession extends DebugSession {
     protected async logServerVersion() {
         log.debug("sending sever_version Request ...");
         if (this.connection) {
-            this.connection.once('serverVersion', (response: any) => {
-                log.info(`Determined version ${response.version ? response.version : undefined} of remote debugger`);
+            await this.connection.sendRequest(new Command('server_version'), async (response: Response) => {
+                log.info(`Determined version ${response.content.version ? response.content.version : undefined} of remote debugger`);
              });
-            await this.connection.sendRequest(new Command('server_version'));
         } else {
             log.error("Connection must not be undefined to log server version.");
             throw new Error("Connection must not be undefined to log server version.");

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -222,7 +222,7 @@ export class Command {
             return 'get_available_contexts\n';
         }
         if (this.name === 'server_version') {
-            return 'server_version\n';
+            return `server_version/${this.id}\n`;
         }
         if (this.name === 'exit') {
             return 'exit\n';

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -20,6 +20,7 @@ export enum ErrorCode {
 }
 
 export type CommandName =
+    'server_version' |
     'pc' |
     'step' |
     'next' |
@@ -41,6 +42,7 @@ export type CommandName =
 export type ResponseType = 'info' | 'error';
 
 export type ResponseSubType =
+    'server_version' |
     'pc' |
     'source_code' |
     'all_breakpoints_deleted' |
@@ -218,6 +220,9 @@ export class Command {
     public toString(): string {
         if (this.name === 'get_available_contexts') {
             return 'get_available_contexts\n';
+        }
+        if (this.name === 'server_version') {
+            return 'server_version\n';
         }
         if (this.name === 'exit') {
             return 'exit\n';


### PR DESCRIPTION
Now the server version of the remote debugger is logged in the log file
for either a launch or an attach request. The line in the log file looks like:
`Determined version ${response.version ? response.version : undefined} of remote debugger`
and it's log level is info.