### PR TITLE
Pause VSCode's debugger if the remote contexts halts during attach requests.

### DIFF
--- a/src/debugSession.ts
+++ b/src/debugSession.ts
@@ -333,6 +333,10 @@ export class JanusDebugSession extends DebugSession {
         const connection = new DebugConnection(socket);
         this.connection = connection;
 
+        this.connection.on('contextPaused', (ctxId: number) => {
+            this.sendEvent(new StoppedEvent("hit breakpoint", ctxId));
+        });
+
         this.logServerVersion();
 
         socket.on('connect', async () => {


### PR DESCRIPTION
Add a event handler to attachRequest() to send a StoppedEvent if a breakpoint or debugger statement is hit during attach requests.