### PR TITLE
Do not show output panel unnecessarily

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,8 +164,6 @@ function printVersion(outputChannel: vscode.OutputChannel) {
             outputChannel.appendLine("Version: " + version.getVersion().toString(true));
         } catch (err) {
             outputChannel.appendLine('getVersion() failed: ' + err.message);
-        } finally {
-            outputChannel.show();
         }
     }
 }


### PR DESCRIPTION
No need to show output panel _every_ time a user opens a folder. Fixes issue #142. Two line diff. Took 2 minutes to find.