### PR TITLE
Implemented "open script console on run script" option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ The following features can be influenced by settings (in `settings.json`)
 **Server Console**
 * Will be connected and disconnected automatically, if setting `autoConnect` in `vscode-janus-debug.serverConsole` is to `true`.
 
+**Script Console**
+* By default the Script Console will open, when running a script. To prevent this, you change the setting `openScriptConsoleOnRunScript` to `false`.
+
 **Auto-upload script on save**
 * Scripts can be automatically uploaded every time you save the file. The default behavior is, that you will be asked at every time you press `Ctrl + S`, if the script should be uploaded. You can specify scripts that should always or never be uploaded without asking. Or you can switch this feature off by answering `Never upload scripts automatically`. If you want to turn the feature on again later, you only have to set `vscode-janus-debug.uploadOnSaveGlobal` to `true` in your **user** settings.
 

--- a/package.json
+++ b/package.json
@@ -341,6 +341,12 @@
             }
           }
         },
+        "vscode-janus-debug.openScriptConsoleOnRunScript": {
+          "type": "boolean",
+          "title": "Automatically open the Script Console when running a script.",
+          "default": true,
+          "description": "When set to 'true' the Script Console will be opened when the user runs a script from this extension."
+        },
         "vscode-janus-debug.browser": {
           "type": "string",
           "description": "Specifies the browser for 'View Documentation In Browser'. (Based on https://github.com/pwnall/node-open)",
@@ -614,6 +620,7 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./ && node ./scripts/createVersionNumber.js",
     "watch": "tsc -watch -p ./",
+    "test": "npm run compile && mocha",
     "test": "npm run compile && mocha",
     "lint": "tslint src/*.ts test/*.ts",
     "coverage": "nyc mocha",

--- a/package.json
+++ b/package.json
@@ -621,7 +621,6 @@
     "compile": "tsc -p ./ && node ./scripts/createVersionNumber.js",
     "watch": "tsc -watch -p ./",
     "test": "npm run compile && mocha",
-    "test": "npm run compile && mocha",
     "lint": "tslint src/*.ts test/*.ts",
     "coverage": "nyc mocha",
     "report": "nyc report",

--- a/src/serverCommands.ts
+++ b/src/serverCommands.ts
@@ -194,8 +194,10 @@ export function uploadAll(loginData: nodeDoc.ConnectionInformation, paramPath: a
 
 
 function runScriptCommon(loginData: nodeDoc.ConnectionInformation, param: any, outputChannel: vscode.OutputChannel): Promise<string> {
-    return new Promise<string>(async (resolve, reject) => {
+    const extensionSettings = vscode.workspace.getConfiguration('vscode-janus-debug');
+    const openOutputChannel = extensionSettings.get('openScriptConsoleOnRunScript', true);
 
+    return new Promise<string>(async (resolve, reject) => {
         try {
             await login.ensureLoginInformation(loginData);
             let serverScriptNames;
@@ -206,7 +208,9 @@ function runScriptCommon(loginData: nodeDoc.ConnectionInformation, param: any, o
             const script = new nodeDoc.scriptT(scriptName, '');
 
             outputChannel.append('Start script at ' + getTime() + os.EOL);
-            outputChannel.show();
+            if (openOutputChannel) {
+                outputChannel.show();
+            }
 
             await nodeDoc.serverSession(loginData, [script], nodeDoc.runScript);
 
@@ -217,7 +221,9 @@ function runScriptCommon(loginData: nodeDoc.ConnectionInformation, param: any, o
             }
             outputChannel.append(script.output + os.EOL);
             outputChannel.append(`Script finished at ` + getTime() + ` on ` + loginData.server + ` ${ver}` + os.EOL);
-            outputChannel.show();
+            if (openOutputChannel) {
+                outputChannel.show();
+            }
 
             helpers.scriptLog(script.output);
 


### PR DESCRIPTION
This should implement feature #165.
Added this option only to the "run script" command because I didn't think this would be needed for the other run options.